### PR TITLE
Add support for home directory configuration (~/.patcher)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run standard tests
+      run: npm test
+    
+    - name: Run home config tests
+      run: npm run test:home-config
+      
+    - name: Run individual test commands
+      run: |
+        npm run test:patch
+        npm run test:undo

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ ThumbsJP.db
 
 # SpecStory files
 .specstory/
+
+**/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 - Install: `npm install`
-- Run: `node src/cli.js <config-file>` or `npm run patcher <config-file>`
+- Run with config file: `node src/cli.js <config-file>` or `npm run patcher <config-file>`
+- Run with package name: `node src/cli.js <package-name>` (uses config from ~/.patcher)
+- Create config: `node src/cli.js --create <package-name>` (creates in ~/.patcher)
 - Test: `npm test`
 - Patch test: `npm run test:patch`
 - Undo patch test: `npm run test:undo`
+- Home config test: `npm run test:home-config`
+- Run single test: `node local-test-runner.js`
 
 ## Publishing
 ⚠️ **EXTREMELY IMPORTANT**: NEVER attempt to publish with `npm publish` directly. ALWAYS use GitHub CI for publishing.
@@ -35,28 +39,34 @@ These actions will ALWAYS fail and potentially expose credentials.
 
 ## Code Style Guidelines
 - **Formatting**: Use 2-space indentation for JavaScript
-- **Imports**: Use ES Modules (`import`/`export`) pattern
+- **Imports**: Use ES Modules (`import`/`export`) pattern with Node.js native modules prefixed with 'node:'
 - **Error handling**: Use try/catch with descriptive error messages
-- **Documentation**: Use JSDoc for function documentation
+- **Documentation**: Use JSDoc for function documentation with all parameters described
 - **Naming**: Use camelCase for variables/functions
 - **Structure**: Keep modules focused on single responsibilities
 - **String replacement**: Use direct string replacement (`string.replace`)
 - **Input validation**: Validate inputs at function start
 - **Configuration**: Supports both JSON and JavaScript module configuration formats
+- **Consistency**: Follow existing patterns in the codebase
 
 ## Project Structure
 - **src/index.js**: Core patching functionality
 - **src/cli.js**: Command-line interface
+- **src/home-config.js**: Home directory configuration management
 - **local-config.json**: Example JSON config for patching local packages
 - **example-config.js**: Example JavaScript module config with template literals
 - **local-test-runner.js**: Script to test the patching results
+- **test.js**: Simple test script for verifying patching functionality
+- **test/home-config.test.js**: Test for home directory configuration feature
 
 ## Testing
-- `npm test`: Test without patches
+- `npm test`: Run full test suite (patch, verify, undo)
 - `npm run test:patch`: Apply patches to local is-odd package
 - `npm run test:undo`: Revert patches
+- `node local-test-runner.js`: Test if patching was successful
 
 When testing, ensure you:
 1. Use same runtime (npm/node) for patching and testing
 2. Clear Node.js module cache when testing modifications 
 3. Run tests in expected order (test → patch → test → undo → test)
+4. Verify that patches can be applied and undone correctly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,14 @@ These actions will ALWAYS fail and potentially expose credentials.
 - **Structure**: Keep modules focused on single responsibilities
 - **String replacement**: Use direct string replacement (`string.replace`)
 - **Input validation**: Validate inputs at function start
-- **Configuration**: Supports both JSON and JavaScript module configuration formats
+- **Configuration**: Uses JavaScript module format (.js) for configuration files
 - **Consistency**: Follow existing patterns in the codebase
 
 ## Project Structure
 - **src/index.js**: Core patching functionality
 - **src/cli.js**: Command-line interface
 - **src/home-config.js**: Home directory configuration management
-- **local-config.json**: Example JSON config for patching local packages
+- **local-config.js**: Example JS config for patching local packages
 - **example-config.js**: Example JavaScript module config with template literals
 - **local-test-runner.js**: Script to test the patching results
 - **test.js**: Simple test script for verifying patching functionality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,26 @@ The publishing process is FULLY AUTOMATED via GitHub Actions workflow:
 - Authentication and publishing happen in the CI environment
 - Local credentials should NEVER be used
 
-To publish a new version:
+### Automated Publishing (Recommended)
+
+To publish a new version using the automated script:
+
+```bash
+npm run publish:version
+```
+
+This script will:
+1. Check if you're on the main branch
+2. Verify there are no uncommitted changes
+3. Show current versions and prompt for the type of version bump (major, minor, patch, or custom)
+4. Update versions in both package.json AND src/cli.js
+5. Commit and push changes to GitHub
+6. Create and push a tag matching the version
+7. GitHub Actions will then automatically run tests and publish the package
+
+### Manual Publishing (Not Recommended)
+
+If you need to manually publish (avoid this if possible):
 1. Update the version in both package.json AND src/cli.js
 2. Commit and push changes to GitHub
 3. Create a new tag: `git tag v0.3.x && git push origin v0.3.x`

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ There are two ways to use patcher:
 
 ### Option 1: Using Configuration Files
 
-Create a configuration file (e.g., `patch-config.json` or `patch-config.js`):
+Create a JavaScript configuration file (e.g., `patch-config.js`):
 
-```json
-{
-  "packagePath": "/path/to/node_modules/package-to-patch/dist/index.js",
-  "beautify": true,
-  "replacements": [
+```js
+// patch-config.js
+export default {
+  packagePath: "/path/to/node_modules/package-to-patch/dist/index.js",
+  beautify: true,
+  replacements: [
     ["original string 1", "replacement string 1"],
     ["original string 2", "replacement string 2"]
   ]
@@ -41,12 +42,13 @@ Create a configuration file (e.g., `patch-config.json` or `patch-config.js`):
 
 Or use a global npm package name:
 
-```json
-{
-  "globalNpmPackage": "package-name",
-  "relativePath": "index.js",
-  "beautify": true,
-  "replacements": [
+```js
+// patch-config.js
+export default {
+  globalNpmPackage: "package-name",
+  relativePath: "index.js",
+  beautify: true,
+  replacements: [
     ["original string 1", "replacement string 1"],
     ["original string 2", "replacement string 2"]
   ]
@@ -56,25 +58,25 @@ Or use a global npm package name:
 #### Apply Patches with Config File
 
 ```
-npx @vabole/patcher patch-config.json
+npx @vabole/patcher patch-config.js
 ```
 
 Or if installed globally:
 
 ```
-patcher patch-config.json
+patcher patch-config.js
 ```
 
 #### Undo Patches with Config File
 
 ```
-npx @vabole/patcher --undo patch-config.json
+npx @vabole/patcher --undo patch-config.js
 ```
 
 Or if installed globally:
 
 ```
-patcher --undo patch-config.json
+patcher --undo patch-config.js
 ```
 
 ### Option 2: Using Package Names Directly
@@ -87,7 +89,7 @@ You can store package configurations in your home directory at `~/.patcher/` and
 patcher --create is-odd
 ```
 
-This creates a default configuration file at `~/.patcher/is-odd.json` that you can edit to add your replacements.
+This creates a default configuration file at `~/.patcher/is-odd.js` that you can edit to add your replacements.
 
 #### Apply Patches with Package Name
 
@@ -114,12 +116,9 @@ patcher --undo is-odd
 
 ## Home Directory Configuration
 
-When using package names directly, patcher looks for configuration files in the `~/.patcher/` directory. For each package, you can have either:
+When using package names directly, patcher looks for configuration files in the `~/.patcher/` directory:
 
-- `~/.patcher/<package-name>.json` - JSON configuration file
 - `~/.patcher/<package-name>.js` - JavaScript module configuration file
-
-If both exist, the JSON file takes precedence.
 
 ### Creating Default Configuration
 
@@ -129,36 +128,28 @@ You can create a default configuration file with:
 patcher --create <package-name>
 ```
 
-This generates a basic JSON configuration file that you can edit to add your specific replacements.
+This generates a JavaScript configuration file that you can edit to add your specific replacements.
 
-## Configuration Formats
+## Configuration Format
 
-You can use either JSON or JavaScript module format for your configuration.
-
-### JSON Format
-
-```json
-{
-  "globalNpmPackage": "is-odd",
-  "replacements": [
-    ["original string", "replacement string"]
-  ]
-}
-```
-
-### JavaScript Module Format
+Configuration files must use JavaScript module format (`.js` files):
 
 ```js
-// patch-config.js
+// package-name.js
 export default {
-  globalNpmPackage: "is-odd",
+  globalNpmPackage: "package-name",
+  // or packagePath: "/path/to/file.js",
+  beautify: true,  // optional, defaults to true
+  relativePath: "path/within/package", // optional, defaults to "index.js"
+  targetFile: "specific/file.js", // optional, overrides default path resolution
   replacements: [
     [
       "original string", 
       `replacement string
       with multiple lines
       without escaping`
-    ]
+    ],
+    ["another string to replace", "replacement"]
   ]
 }
 ```
@@ -169,11 +160,16 @@ export default {
 
 Patching the `is-odd` package to throw an error when zero is provided:
 
-```json
-{
-  "globalNpmPackage": "is-odd",
-  "replacements": [
-    ["module.exports = function isOdd(value) {", "module.exports = function isOdd(value) {\n  if (value === 0) throw new Error('zero is not allowed');"]
+```js
+// is-odd.js
+export default {
+  globalNpmPackage: "is-odd",
+  replacements: [
+    [
+      "module.exports = function isOdd(value) {", 
+      `module.exports = function isOdd(value) {
+  if (value === 0) throw new Error('zero is not allowed');`
+    ]
   ]
 }
 ```
@@ -182,12 +178,17 @@ Patching the `is-odd` package to throw an error when zero is provided:
 
 When the package's entry point is not the file you want to patch, or when you want to patch a different file:
 
-```json
-{
-  "globalNpmPackage": "@anthropic-ai/claude-code",
-  "targetFile": "lib/main.js",
-  "replacements": [
-    ["function processInput(", "function processInput(\n  // Add custom validation\n"]
+```js
+// claude-code.js
+export default {
+  globalNpmPackage: "@anthropic-ai/claude-code",
+  targetFile: "lib/main.js",
+  replacements: [
+    [
+      "function processInput(", 
+      `function processInput(
+  // Add custom validation`
+    ]
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ npm install
 
 ## Usage
 
+There are two ways to use patcher:
+
+1. **Configuration File Approach**: Create and specify a configuration file
+2. **Package Name Approach**: Use package names directly with configurations stored in `~/.patcher/`
+
+### Option 1: Using Configuration Files
+
 Create a configuration file (e.g., `patch-config.json` or `patch-config.js`):
 
 ```json
@@ -46,7 +53,7 @@ Or use a global npm package name:
 }
 ```
 
-### Apply Patches
+#### Apply Patches with Config File
 
 ```
 npx @vabole/patcher patch-config.json
@@ -58,7 +65,7 @@ Or if installed globally:
 patcher patch-config.json
 ```
 
-### Undo Patches
+#### Undo Patches with Config File
 
 ```
 npx @vabole/patcher --undo patch-config.json
@@ -68,6 +75,30 @@ Or if installed globally:
 
 ```
 patcher --undo patch-config.json
+```
+
+### Option 2: Using Package Names Directly
+
+You can store package configurations in your home directory at `~/.patcher/` and use package names directly.
+
+#### Create a Configuration File
+
+```
+patcher --create is-odd
+```
+
+This creates a default configuration file at `~/.patcher/is-odd.json` that you can edit to add your replacements.
+
+#### Apply Patches with Package Name
+
+```
+patcher is-odd
+```
+
+#### Undo Patches with Package Name
+
+```
+patcher --undo is-odd
 ```
 
 ## Configuration Options
@@ -80,6 +111,25 @@ patcher --undo patch-config.json
 | `targetFile` | string | (Optional) Specific file to patch, overriding normal entry point resolution |
 | `beautify` | boolean | (Optional) Whether to beautify the code before patching (default: true) |
 | `replacements` | array | Array of [original, replacement] string pairs |
+
+## Home Directory Configuration
+
+When using package names directly, patcher looks for configuration files in the `~/.patcher/` directory. For each package, you can have either:
+
+- `~/.patcher/<package-name>.json` - JSON configuration file
+- `~/.patcher/<package-name>.js` - JavaScript module configuration file
+
+If both exist, the JSON file takes precedence.
+
+### Creating Default Configuration
+
+You can create a default configuration file with:
+
+```
+patcher --create <package-name>
+```
+
+This generates a basic JSON configuration file that you can edit to add your specific replacements.
 
 ## Configuration Formats
 

--- a/local-config.js
+++ b/local-config.js
@@ -1,0 +1,12 @@
+// Configuration for local is-odd package
+export default {
+  packagePath: "node_modules/is-odd/index.js",
+  beautify: false,
+  replacements: [
+    [
+      "module.exports = function isOdd(value) {", 
+      `module.exports = function isOdd(value) {
+  if (value === 0) throw new Error('zero is not allowed');`
+    ]
+  ]
+}

--- a/local-config.json
+++ b/local-config.json
@@ -1,7 +1,0 @@
-{
-  "packagePath": "node_modules/is-odd/index.js",
-  "beautify": false,
-  "replacements": [
-    ["module.exports = function isOdd(value) {", "module.exports = function isOdd(value) {\n  if (value === 0) throw new Error('zero is not allowed');"]
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "patcher": "node src/cli.js",
-    "test": "node src/cli.js test-config.json && node local-test-runner.js && node src/cli.js --undo test-config.json",
-    "test:patch": "node src/cli.js local-config.json",
-    "test:undo": "node src/cli.js --undo local-config.json",
+    "test": "node src/cli.js test-config.js && node local-test-runner.js && node src/cli.js --undo test-config.js",
+    "test:patch": "node src/cli.js local-config.js",
+    "test:undo": "node src/cli.js --undo local-config.js",
     "test:home-config": "node test/run-home-config-test.js",
     "prepublishOnly": "npm test"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:patch": "node src/cli.js local-config.js",
     "test:undo": "node src/cli.js --undo local-config.js",
     "test:home-config": "node test/run-home-config-test.js",
-    "prepublishOnly": "npm test"
+    "publish:version": "node scripts/publish.js",
+    "prepublishOnly": "echo \"ERROR: Do not use npm publish directly. Use npm run publish:version instead.\" && exit 1"
   },
   "keywords": [
     "patch",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "node src/cli.js test-config.json && node local-test-runner.js && node src/cli.js --undo test-config.json",
     "test:patch": "node src/cli.js local-config.json",
     "test:undo": "node src/cli.js --undo local-config.json",
+    "test:home-config": "node test/run-home-config-test.js",
     "prepublishOnly": "npm test"
   },
   "keywords": [

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import readline from 'node:readline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, '..');
+
+// Paths
+const packageJsonPath = path.join(rootDir, 'package.json');
+const cliJsPath = path.join(rootDir, 'src', 'cli.js');
+
+// Create readline interface for user input
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+/**
+ * Ask a question and get user input
+ * @param {string} question The question to ask
+ * @returns {Promise<string>} The user's answer
+ */
+function askQuestion(question) {
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      resolve(answer);
+    });
+  });
+}
+
+/**
+ * Read package.json and parse it
+ * @returns {object} The parsed package.json
+ */
+function getPackageJson() {
+  const content = fs.readFileSync(packageJsonPath, 'utf8');
+  return JSON.parse(content);
+}
+
+/**
+ * Read cli.js and extract the version
+ * @returns {string} The current version in cli.js
+ */
+function getCliVersion() {
+  const content = fs.readFileSync(cliJsPath, 'utf8');
+  const versionMatch = content.match(/\.version\(['"]([^'"]+)['"]\)/);
+  if (!versionMatch) {
+    throw new Error('Could not extract version from cli.js');
+  }
+  return versionMatch[1];
+}
+
+/**
+ * Update the version in package.json
+ * @param {string} newVersion The new version to set
+ */
+function updatePackageJson(newVersion) {
+  const pkg = getPackageJson();
+  pkg.version = newVersion;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+  console.log(`✓ Updated version in package.json to ${newVersion}`);
+}
+
+/**
+ * Update the version in cli.js
+ * @param {string} newVersion The new version to set
+ */
+function updateCliJs(newVersion) {
+  let content = fs.readFileSync(cliJsPath, 'utf8');
+  content = content.replace(
+    /\.version\(['"]([^'"]+)['"]\)/,
+    `.version('${newVersion}')`
+  );
+  fs.writeFileSync(cliJsPath, content, 'utf8');
+  console.log(`✓ Updated version in cli.js to ${newVersion}`);
+}
+
+/**
+ * Create and push a Git tag for the version
+ * @param {string} version The version to tag
+ */
+function createAndPushTag(version) {
+  try {
+    // Check if we're on main branch
+    const currentBranch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+    if (currentBranch !== 'main') {
+      throw new Error(`You are on branch '${currentBranch}'. You need to be on 'main' branch to publish.`);
+    }
+    
+    // Stage changes
+    console.log('Committing version changes...');
+    execSync('git add package.json src/cli.js', { stdio: 'inherit' });
+    execSync(`git commit -m "Update version to ${version}"`, { stdio: 'inherit' });
+    
+    // Push changes to main
+    console.log('Pushing changes to main...');
+    execSync('git push origin main', { stdio: 'inherit' });
+    
+    // Create and push tag
+    console.log(`Creating tag v${version}...`);
+    execSync(`git tag v${version}`, { stdio: 'inherit' });
+    execSync(`git push origin v${version}`, { stdio: 'inherit' });
+    
+    console.log(`✓ Successfully created and pushed tag v${version}`);
+    console.log('GitHub Actions will now run tests and publish the package to npm.');
+  } catch (error) {
+    console.error('Error in Git operations:', error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Check if there are uncommitted changes
+ * @returns {boolean} True if there are uncommitted changes
+ */
+function hasUncommittedChanges() {
+  try {
+    const status = execSync('git status --porcelain', { encoding: 'utf8' });
+    return status.trim() !== '';
+  } catch (error) {
+    console.error('Error checking Git status:', error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Calculate the next version based on the current version and bump type
+ * @param {string} currentVersion The current version
+ * @param {string} bumpType The type of bump (major, minor, patch)
+ * @returns {string} The next version
+ */
+function calculateNextVersion(currentVersion, bumpType) {
+  const [major, minor, patch] = currentVersion.split('.').map(Number);
+  
+  switch (bumpType) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      return currentVersion;
+  }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  try {
+    console.log('=== Patcher Publishing Tool ===');
+    
+    // Check for uncommitted changes
+    if (hasUncommittedChanges()) {
+      console.error('❌ Error: You have uncommitted changes. Please commit or stash them before publishing.');
+      process.exit(1);
+    }
+    
+    // Get current versions
+    const pkgVersion = getPackageJson().version;
+    const cliVersion = getCliVersion();
+    
+    console.log(`Current version in package.json: ${pkgVersion}`);
+    console.log(`Current version in cli.js: ${cliVersion}`);
+    
+    // Ensure versions match
+    if (pkgVersion !== cliVersion) {
+      console.error(`❌ Error: Version mismatch between package.json (${pkgVersion}) and cli.js (${cliVersion})`);
+      process.exit(1);
+    }
+    
+    // Ask for version bump type
+    console.log('\nWhat kind of version bump would you like to make?');
+    console.log('1. major (x.0.0) - Breaking changes');
+    console.log('2. minor (0.x.0) - New features, no breaking changes');
+    console.log('3. patch (0.0.x) - Bug fixes, no new features or breaking changes');
+    console.log('4. custom - Enter a custom version number');
+    
+    const bumpChoice = await askQuestion('\nEnter your choice (1-4): ');
+    
+    let newVersion;
+    
+    switch (bumpChoice) {
+      case '1':
+        newVersion = calculateNextVersion(pkgVersion, 'major');
+        break;
+      case '2':
+        newVersion = calculateNextVersion(pkgVersion, 'minor');
+        break;
+      case '3':
+        newVersion = calculateNextVersion(pkgVersion, 'patch');
+        break;
+      case '4':
+        newVersion = await askQuestion('\nEnter custom version (e.g., 1.2.3): ');
+        // Validate version format
+        if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
+          console.error('❌ Error: Invalid version format. Expected format: x.y.z (e.g., 1.2.3)');
+          process.exit(1);
+        }
+        break;
+      default:
+        console.error('❌ Error: Invalid choice');
+        process.exit(1);
+    }
+    
+    console.log(`\nUpdating from ${pkgVersion} to ${newVersion}`);
+    
+    // Confirm before proceeding
+    const confirm = await askQuestion('\nDo you want to proceed with the version update and publish? (y/n): ');
+    
+    if (confirm.toLowerCase() !== 'y') {
+      console.log('Publishing aborted.');
+      process.exit(0);
+    }
+    
+    // Update versions
+    updatePackageJson(newVersion);
+    updateCliJs(newVersion);
+    
+    // Create and push tag
+    createAndPushTag(newVersion);
+    
+    console.log('\n✅ Publishing process initiated successfully!');
+    console.log('The package will be published by GitHub Actions once the workflow completes.');
+    
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+  } finally {
+    rl.close();
+  }
+}
+
+// Run the main function
+main();

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as patcher from './index.js';
+import * as homeConfig from './home-config.js';
 
 const program = new Command();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -14,14 +15,46 @@ program
   .name('patcher')
   .description('Patch installed npm packages')
   .version('0.3.1')
-  .argument('<config>', 'Path to configuration file')
+  .argument('<package-or-config>', 'Package name or path to configuration file')
   .option('-u, --undo', 'Undo previous patches')
-  .action(async (configPath, options) => {
+  .option('-c, --create', 'Create a default configuration file for the package in ~/.patcher')
+  .action(async (packageOrConfig, options) => {
     try {
-      // Support both .json and .js config files
-      const config = configPath.endsWith('.js') 
-        ? (await import(path.resolve(configPath))).default
-        : JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      let config;
+      const isPackageName = !packageOrConfig.includes('/') && 
+                           !packageOrConfig.endsWith('.js') && 
+                           !packageOrConfig.endsWith('.json');
+      
+      if (isPackageName) {
+        // Package name provided - look for configuration in ~/.patcher
+        const packageName = packageOrConfig;
+        console.log(chalk.blue(`Looking for configuration for ${packageName} in ~/.patcher`));
+        
+        if (options.create) {
+          // Create a default configuration file
+          const configPath = await homeConfig.createDefaultConfig(packageName);
+          console.log(chalk.green(`Created default configuration at ${configPath}`));
+          console.log(chalk.yellow('Please edit this file to add your replacements before applying patches.'));
+          return;
+        }
+        
+        config = await homeConfig.loadPackageConfig(packageName);
+        
+        if (!config) {
+          console.error(chalk.red(`No configuration found for ${packageName} in ~/.patcher`));
+          console.log(chalk.blue(`Use --create to create a default configuration file, or provide a path to a configuration file.`));
+          process.exit(1);
+        }
+      } else {
+        // Configuration file path provided
+        const configPath = packageOrConfig;
+        console.log(chalk.blue(`Using configuration file: ${configPath}`));
+        
+        // Support both .json and .js config files
+        config = configPath.endsWith('.js') 
+          ? (await import(path.resolve(configPath))).default
+          : JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      }
       
       if (options.undo) {
         patcher.undoPatch(config);

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,8 +22,7 @@ program
     try {
       let config;
       const isPackageName = !packageOrConfig.includes('/') && 
-                           !packageOrConfig.endsWith('.js') && 
-                           !packageOrConfig.endsWith('.json');
+                           !packageOrConfig.endsWith('.js');
       
       if (isPackageName) {
         // Package name provided - look for configuration in ~/.patcher
@@ -50,10 +49,14 @@ program
         const configPath = packageOrConfig;
         console.log(chalk.blue(`Using configuration file: ${configPath}`));
         
-        // Support both .json and .js config files
-        config = configPath.endsWith('.js') 
-          ? (await import(path.resolve(configPath))).default
-          : JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        // Only support .js config files
+        if (!configPath.endsWith('.js')) {
+          console.error(chalk.red('Error: Only JavaScript (.js) configuration files are supported.'));
+          console.log(chalk.blue('Please convert your configuration to a .js file.'));
+          process.exit(1);
+        }
+        
+        config = (await import(path.resolve(configPath))).default;
       }
       
       if (options.undo) {

--- a/src/home-config.js
+++ b/src/home-config.js
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * Gets the path to the patcher configuration directory in the user's home directory
+ * @returns {string} Path to the configuration directory
+ */
+export function getConfigDir() {
+  const homeDir = os.homedir();
+  return path.join(homeDir, '.patcher');
+}
+
+/**
+ * Checks if a configuration file exists for the given package
+ * @param {string} packageName Name of the npm package
+ * @returns {string|null} Path to the configuration file, or null if none exists
+ */
+export function findPackageConfig(packageName) {
+  const configDir = getConfigDir();
+  
+  // Check if the configuration directory exists
+  if (!fs.existsSync(configDir)) {
+    return null;
+  }
+  
+  // Try JSON format first
+  const jsonPath = path.join(configDir, `${packageName}.json`);
+  if (fs.existsSync(jsonPath)) {
+    return jsonPath;
+  }
+  
+  // Then try JavaScript module format
+  const jsPath = path.join(configDir, `${packageName}.js`);
+  if (fs.existsSync(jsPath)) {
+    return jsPath;
+  }
+  
+  return null;
+}
+
+/**
+ * Loads the configuration for the given package
+ * @param {string} packageName Name of the npm package
+ * @returns {Promise<Object|null>} Configuration object or null if not found
+ */
+export async function loadPackageConfig(packageName) {
+  const configPath = findPackageConfig(packageName);
+  
+  if (!configPath) {
+    return null;
+  }
+  
+  try {
+    if (configPath.endsWith('.js')) {
+      // Import JavaScript module
+      const config = (await import(path.resolve(configPath))).default;
+      
+      // Ensure globalNpmPackage is set if it isn't already
+      if (!config.globalNpmPackage && !config.packagePath) {
+        config.globalNpmPackage = packageName;
+      }
+      
+      return config;
+    } else {
+      // Read JSON file
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      
+      // Ensure globalNpmPackage is set if it isn't already
+      if (!config.globalNpmPackage && !config.packagePath) {
+        config.globalNpmPackage = packageName;
+      }
+      
+      return config;
+    }
+  } catch (error) {
+    throw new Error(`Failed to load configuration for ${packageName}: ${error.message}`);
+  }
+}
+
+/**
+ * Creates a default configuration file for the given package
+ * @param {string} packageName Name of the npm package
+ * @returns {Promise<string>} Path to the created configuration file
+ */
+export async function createDefaultConfig(packageName) {
+  const configDir = getConfigDir();
+  
+  // Create the configuration directory if it doesn't exist
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  
+  const configPath = path.join(configDir, `${packageName}.json`);
+  
+  // Create a default configuration file
+  const defaultConfig = {
+    globalNpmPackage: packageName,
+    beautify: true,
+    replacements: [
+      // Add a placeholder replacement
+      ["// Add your replacements here", "// Modified by patcher"]
+    ]
+  };
+  
+  fs.writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2), 'utf8');
+  
+  return configPath;
+}

--- a/src/home-config.js
+++ b/src/home-config.js
@@ -24,13 +24,7 @@ export function findPackageConfig(packageName) {
     return null;
   }
   
-  // Try JSON format first
-  const jsonPath = path.join(configDir, `${packageName}.json`);
-  if (fs.existsSync(jsonPath)) {
-    return jsonPath;
-  }
-  
-  // Then try JavaScript module format
+  // Only use JavaScript module format
   const jsPath = path.join(configDir, `${packageName}.js`);
   if (fs.existsSync(jsPath)) {
     return jsPath;
@@ -52,27 +46,15 @@ export async function loadPackageConfig(packageName) {
   }
   
   try {
-    if (configPath.endsWith('.js')) {
-      // Import JavaScript module
-      const config = (await import(path.resolve(configPath))).default;
-      
-      // Ensure globalNpmPackage is set if it isn't already
-      if (!config.globalNpmPackage && !config.packagePath) {
-        config.globalNpmPackage = packageName;
-      }
-      
-      return config;
-    } else {
-      // Read JSON file
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      
-      // Ensure globalNpmPackage is set if it isn't already
-      if (!config.globalNpmPackage && !config.packagePath) {
-        config.globalNpmPackage = packageName;
-      }
-      
-      return config;
+    // Import JavaScript module
+    const config = (await import(path.resolve(configPath))).default;
+    
+    // Ensure globalNpmPackage is set if it isn't already
+    if (!config.globalNpmPackage && !config.packagePath) {
+      config.globalNpmPackage = packageName;
     }
+    
+    return config;
   } catch (error) {
     throw new Error(`Failed to load configuration for ${packageName}: ${error.message}`);
   }
@@ -91,19 +73,22 @@ export async function createDefaultConfig(packageName) {
     fs.mkdirSync(configDir, { recursive: true });
   }
   
-  const configPath = path.join(configDir, `${packageName}.json`);
+  const configPath = path.join(configDir, `${packageName}.js`);
   
   // Create a default configuration file
-  const defaultConfig = {
-    globalNpmPackage: packageName,
-    beautify: true,
-    replacements: [
-      // Add a placeholder replacement
-      ["// Add your replacements here", "// Modified by patcher"]
+  const defaultConfigContent = `// Configuration for ${packageName} package
+export default {
+  globalNpmPackage: "${packageName}",
+  beautify: true,
+  replacements: [
+    [
+      "// Add your replacements here", 
+      "// Modified by patcher"
     ]
-  };
+  ]
+}`;
   
-  fs.writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2), 'utf8');
+  fs.writeFileSync(configPath, defaultConfigContent, 'utf8');
   
   return configPath;
 }

--- a/test-config.js
+++ b/test-config.js
@@ -1,0 +1,12 @@
+// Configuration for testing
+export default {
+  packagePath: "node_modules/is-odd/index.js",
+  beautify: false,
+  replacements: [
+    [
+      "module.exports = function isOdd(value) {", 
+      `module.exports = function isOdd(value) {
+  if (value === 0) throw new Error('zero is not allowed');`
+    ]
+  ]
+}

--- a/test-config.json
+++ b/test-config.json
@@ -1,7 +1,0 @@
-{
-  "packagePath": "node_modules/is-odd/index.js",
-  "beautify": false,
-  "replacements": [
-    ["module.exports = function isOdd(value) {", "module.exports = function isOdd(value) {\n  if (value === 0) throw new Error('zero is not allowed');"]
-  ]
-}

--- a/test/fixtures/home/.patcher/is-odd.js
+++ b/test/fixtures/home/.patcher/is-odd.js
@@ -1,0 +1,13 @@
+// Configuration for is-odd package
+export default {
+  packagePath: "node_modules/is-odd/index.js",
+  beautify: false,
+  replacements: [
+    [
+      "module.exports = function isOdd(value) {", 
+      `module.exports = function isOdd(value) {
+  // From ~/.patcher/is-odd.js
+  if (value === 0) throw new Error('zero is not allowed from js config');`
+    ]
+  ]
+}

--- a/test/fixtures/home/.patcher/is-odd.json
+++ b/test/fixtures/home/.patcher/is-odd.json
@@ -1,0 +1,7 @@
+{
+  "packagePath": "node_modules/is-odd/index.js",
+  "beautify": false,
+  "replacements": [
+    ["module.exports = function isOdd(value) {", "module.exports = function isOdd(value) {\n  if (value === 0) throw new Error('zero is not allowed');"]
+  ]
+}

--- a/test/fixtures/home/.patcher/is-odd.json
+++ b/test/fixtures/home/.patcher/is-odd.json
@@ -1,7 +1,0 @@
-{
-  "packagePath": "node_modules/is-odd/index.js",
-  "beautify": false,
-  "replacements": [
-    ["module.exports = function isOdd(value) {", "module.exports = function isOdd(value) {\n  if (value === 0) throw new Error('zero is not allowed');"]
-  ]
-}

--- a/test/home-config.test.js
+++ b/test/home-config.test.js
@@ -61,7 +61,6 @@ function runTest() {
     
     // Make sure our test fixtures exist
     assert(fs.existsSync(homeConfigDir), 'Test fixtures not found');
-    assert(fs.existsSync(path.join(homeConfigDir, 'is-odd.json')), 'is-odd.json not found');
     assert(fs.existsSync(path.join(homeConfigDir, 'is-odd.js')), 'is-odd.js not found');
     console.log('Test fixtures exist.');
     

--- a/test/home-config.test.js
+++ b/test/home-config.test.js
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// Set up paths
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, '..');
+const cliPath = path.join(projectRoot, 'src/cli.js');
+const homePath = path.join(__dirname, 'fixtures/home');
+const homeConfigDir = path.join(homePath, '.patcher');
+const isOddPath = path.join(projectRoot, 'node_modules/is-odd/index.js');
+const isOddBackupPath = path.join(projectRoot, 'node_modules/is-odd/index.js.backup');
+
+// Backup original environment variables
+const originalHome = process.env.HOME;
+
+/**
+ * Create a clean backup of the is-odd package
+ */
+function createCleanBackup() {
+  // Read the current content
+  const content = fs.readFileSync(isOddPath, 'utf8');
+  
+  // Create a clean version (remove the zero check)
+  const cleanedContent = content.replace(/if \(value === 0\) throw new Error\('zero is not allowed'\);\n/, '');
+  
+  // Write the backup
+  fs.writeFileSync(isOddBackupPath, cleanedContent, 'utf8');
+  console.log('Created clean backup of is-odd package');
+  
+  // Restore clean version for testing
+  fs.writeFileSync(isOddPath, cleanedContent, 'utf8');
+  console.log('Restored clean version of is-odd package');
+}
+
+/**
+ * Import a fresh version of is-odd
+ */
+function importIsOdd() {
+  // Force re-importing the module by using a direct path
+  delete require.cache[require.resolve('is-odd')];
+  const isOdd = require('is-odd');
+  return isOdd;
+}
+
+/**
+ * Test home directory configuration for patcher
+ */
+function runTest() {
+  try {
+    console.log('=== Testing home directory configuration ===');
+    
+    // Set HOME environment variable to our test fixtures
+    process.env.HOME = homePath;
+    console.log(`Set HOME to ${homePath}`);
+    
+    // Make sure our test fixtures exist
+    assert(fs.existsSync(homeConfigDir), 'Test fixtures not found');
+    assert(fs.existsSync(path.join(homeConfigDir, 'is-odd.json')), 'is-odd.json not found');
+    assert(fs.existsSync(path.join(homeConfigDir, 'is-odd.js')), 'is-odd.js not found');
+    console.log('Test fixtures exist.');
+    
+    // Create clean backup and restore original version for testing
+    createCleanBackup();
+    
+    // Import is-odd and test before patching
+    let isOdd = importIsOdd();
+    
+    // Test with zero (should NOT throw before patching)
+    try {
+      const result = isOdd(0);
+      console.log('Before patch - isOdd(0):', result);
+    } catch (error) {
+      console.log('Error before patching:', error.message);
+      throw new Error('Should not throw error before patching. Is the package already patched?');
+    }
+    
+    // Apply patch using package name only
+    console.log('Applying patch with: node', cliPath, 'is-odd');
+    try {
+      execSync(`node ${cliPath} is-odd`, { stdio: 'inherit' });
+    } catch (error) {
+      console.error('Error applying patch:', error.message);
+      throw error;
+    }
+    
+    console.log('Patch applied. Testing...');
+    
+    // Test after patching - should throw for zero
+    isOdd = importIsOdd();
+    
+    try {
+      const result = isOdd(0);
+      console.log('After patch - isOdd(0):', result);
+      throw new Error('Expected error was not thrown after patching');
+    } catch (error) {
+      if (error.message.includes('zero is not allowed')) {
+        console.log('Error after patching (expected):', error.message);
+      } else {
+        console.error('Unexpected error after patching:', error.message);
+        throw error;
+      }
+    }
+    
+    // Undo patch
+    console.log('Undoing patch...');
+    try {
+      execSync(`node ${cliPath} --undo is-odd`, { stdio: 'inherit' });
+    } catch (error) {
+      console.error('Error undoing patch:', error.message);
+      throw error;
+    }
+    
+    // Test after undoing patch - should NOT throw for zero
+    isOdd = importIsOdd();
+    
+    try {
+      const result = isOdd(0);
+      console.log('After undo - isOdd(0):', result);
+    } catch (error) {
+      if (error.message.includes('zero is not allowed')) {
+        console.error('Error after undoing patch - patch was not correctly undone:', error.message);
+        throw new Error('Patch was not correctly undone: ' + error.message);
+      } else {
+        console.error('Unexpected error after undoing patch:', error.message);
+        throw error;
+      }
+    }
+    
+    console.log('Test PASSED! Home directory configuration works correctly.');
+    return true;
+  } catch (error) {
+    console.error('Test FAILED:', error.message);
+    return false;
+  } finally {
+    // Restore original HOME
+    process.env.HOME = originalHome;
+    
+    // Restore original content from backup if it exists
+    if (fs.existsSync(isOddBackupPath)) {
+      try {
+        fs.copyFileSync(isOddBackupPath, isOddPath);
+        console.log('Restored original is-odd package from backup');
+      } catch (error) {
+        console.error('Failed to restore original is-odd package:', error.message);
+      }
+    }
+  }
+}
+
+// Run the test
+runTest();
+// We'll let the process exit naturally

--- a/test/run-home-config-test.js
+++ b/test/run-home-config-test.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testPath = path.join(__dirname, 'home-config.test.js');
+
+try {
+  console.log('Running home configuration test...');
+  execSync(`node ${testPath}`, { stdio: 'inherit' });
+  console.log('All tests passed!');
+  process.exit(0);
+} catch (error) {
+  console.error('Test failed:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add support for storing package configuration files in ~/.patcher directory
- Allow using package names directly (e.g., 'patcher is-odd' instead of 'patcher config.js')
- Create default configuration files with --create flag
- Add comprehensive tests and documentation
- Simplify by removing JSON configuration format support - only use JS module format
- Add GitHub Actions workflow for automated testing on PRs

## Test plan
- Run npm run test:home-config to test the new functionality
- Try patching a package using just its name
- GitHub Actions will automatically run tests on this PR