### PR TITLE
Add practical use cases to README with validator package examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,75 @@ export default {
 }
 ```
 
-## Examples
+## Real-World Use Cases
 
-### Basic Example
+Patcher shines when you need to make quick modifications to dependencies without forking them or waiting for upstream changes. Here are some common scenarios where Patcher is invaluable:
 
-Patching the `is-odd` package to throw an error when zero is provided:
+### Customizing Error Messages
+
+Improve error messages to be more user-friendly by patching the `validator` package:
+
+```js
+// validator-error-message.js
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/util/assertString.js",
+  replacements: [
+    [
+      `throw new TypeError("Expected a string but received a ".concat(invalidType));`,
+      `throw new TypeError("Validation failed: Please provide a valid text value instead of a ".concat(invalidType));`
+    ]
+  ]
+}
+```
+
+### Enhancing Security Requirements
+
+Strengthen password requirements in your application by patching validation defaults:
+
+```js
+// stronger-password-requirements.js
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/isStrongPassword.js",
+  replacements: [
+    [
+      `minLength: 8,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 1,
+  minSymbols: 1,`,
+      `minLength: 12,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 2,
+  minSymbols: 2,`
+    ]
+  ]
+}
+```
+
+### Enforcing Company Email Policies
+
+Restrict email validation to only allow specific company domains:
+
+```js
+// company-email-policy.js
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/isEmail.js", 
+  replacements: [
+    [
+      `host_whitelist: []`,
+      `host_whitelist: ['yourcompany.com', 'yourcompany.org']  // Only allow company domains`
+    ]
+  ]
+}
+```
+
+### Fixing Bugs in Dependencies
+
+Add missing functionality to packages while waiting for official fixes:
 
 ```js
 // is-odd.js
@@ -185,7 +249,7 @@ export default {
 
 ### Patching a Specific File
 
-When the package's entry point is not the file you want to patch, or when you want to patch a different file:
+When the package's entry point is not the file you want to patch:
 
 ```js
 // claude-code.js

--- a/examples/company-email-policy.js
+++ b/examples/company-email-policy.js
@@ -1,0 +1,32 @@
+// company-email-policy.js - only allow specific company domains
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/isEmail.js", 
+  beautify: true,
+  replacements: [
+    [
+      `var default_email_options = {
+  allow_display_name: false,
+  allow_underscores: false,
+  require_display_name: false,
+  allow_utf8_local_part: true,
+  require_tld: true,
+  blacklisted_chars: '',
+  ignore_max_length: false,
+  host_blacklist: [],
+  host_whitelist: []
+};`,
+      `var default_email_options = {
+  allow_display_name: false,
+  allow_underscores: false,
+  require_display_name: false,
+  allow_utf8_local_part: true,
+  require_tld: true,
+  blacklisted_chars: '',
+  ignore_max_length: false,
+  host_blacklist: [],
+  host_whitelist: ['yourcompany.com', 'yourcompany.org']  // Only allow company domains
+};` 
+    ]
+  ]
+}

--- a/examples/stronger-password-requirements.js
+++ b/examples/stronger-password-requirements.js
@@ -1,0 +1,38 @@
+// stronger-password-requirements.js
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/isStrongPassword.js", 
+  beautify: true,
+  replacements: [
+    [
+      `var defaultOptions = {
+  minLength: 8,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 1,
+  minSymbols: 1,
+  returnScore: false,
+  pointsPerUnique: 1,
+  pointsPerRepeat: 0.5,
+  pointsForContainingLower: 10,
+  pointsForContainingUpper: 10,
+  pointsForContainingNumber: 10,
+  pointsForContainingSymbol: 10
+};`,
+      `var defaultOptions = {
+  minLength: 12,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 2,
+  minSymbols: 2,
+  returnScore: false,
+  pointsPerUnique: 1,
+  pointsPerRepeat: 0.5,
+  pointsForContainingLower: 10,
+  pointsForContainingUpper: 10,
+  pointsForContainingNumber: 10,
+  pointsForContainingSymbol: 10
+};` 
+    ]
+  ]
+}

--- a/examples/test-validator.js
+++ b/examples/test-validator.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import validator from 'validator';
+
+console.log('=== Testing validator before patching ===');
+console.log('');
+
+try {
+  // This will throw an error with the default message
+  validator.isEmail(123);
+} catch (error) {
+  console.log('Original error message:', error.message);
+}
+
+console.log('');
+console.log('To patch validator with a more friendly error message:');
+console.log('patcher validator-error-message.js');
+console.log('');
+console.log('After patching, the error message would be more user-friendly');
+console.log('');
+
+// Example output of what the patched version would show
+console.log('Patched error would be: "Validation failed: Please provide a valid text value instead of a Number"');
+console.log('');
+console.log('To undo the patch:');
+console.log('patcher --undo validator-error-message.js');

--- a/examples/validator-error-message.js
+++ b/examples/validator-error-message.js
@@ -1,0 +1,26 @@
+// validator-error-message.js
+export default {
+  globalNpmPackage: "validator",
+  targetFile: "lib/util/assertString.js", 
+  beautify: true,
+  replacements: [
+    [
+      `function assertString(input) {
+  var isString = typeof input === 'string' || input instanceof String;
+  if (!isString) {
+    var invalidType = _typeof(input);
+    if (input === null) invalidType = 'null';else if (invalidType === 'object') invalidType = input.constructor.name;
+    throw new TypeError("Expected a string but received a ".concat(invalidType));
+  }
+}`,
+      `function assertString(input) {
+  var isString = typeof input === 'string' || input instanceof String;
+  if (!isString) {
+    var invalidType = _typeof(input);
+    if (input === null) invalidType = 'null';else if (invalidType === 'object') invalidType = input.constructor.name;
+    throw new TypeError("Validation failed: Please provide a valid text value instead of a ".concat(invalidType));
+  }
+}` 
+    ]
+  ]
+}


### PR DESCRIPTION
This PR enhances the README with real-world use cases for the patcher package:

- Adds a new 'Real-World Use Cases' section with practical examples
- Creates working example configurations for patching the validator package:
  - Customizing error messages to be more user-friendly
  - Enhancing password security requirements
  - Enforcing company email domain policies
- Includes a test script to demonstrate the error message customization
- Organizes examples in a practical, problem-solution format

These examples make it much easier for users to understand how patcher can solve common problems without forking dependencies.