### PR TITLE
Fix test configuration for CI publishing workflow

### DIFF
--- a/test-config.js
+++ b/test-config.js
@@ -4,7 +4,7 @@
  */
 export default {
   // Package details
-  globalNpmPackage: "is-odd",
+  packagePath: "node_modules/is-odd/index.js",
   beautify: false,
   
   // Patches to apply


### PR DESCRIPTION
## Summary
- Update test-config.js to use the local package path instead of global npm package
- Ensures tests pass in the publishing workflow in all CI environments

## Why this is needed
The current configuration relies on global package installation which was failing in the publishing workflow despite our attempts to debug the paths. Using the local package in node_modules is more reliable across different CI environments.