### PR TITLE
Remove unnecessary global is-odd installation from CI workflows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,11 +18,4 @@ jobs:
         node-version: 22
         cache: 'npm'
     - run: npm ci
-    - name: Install is-odd globally and find its path
-      run: |
-        npm install -g is-odd
-        which node
-        npm root -g
-        ls -la $(npm root -g)
-        find $(npm root -g) -name is-odd -type d
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
     
-    - name: Install is-odd globally and find its path
-      run: |
-        npm install -g is-odd
-        which node
-        npm root -g
-        ls -la $(npm root -g)
-        find $(npm root -g) -name is-odd -type d
-    
     - name: Run standard tests
       run: npm test
     


### PR DESCRIPTION
## Summary
- Remove global is-odd installation steps from all CI workflow files
- Clean up redundant diagnostic commands

## Why
- Test configuration now uses local package in node_modules instead of global package
- Reduces CI execution time by skipping unnecessary steps
- Removes diagnostic commands that were added for debugging