### PR TITLE
Fix global installation bug

### DIFF
--- a/.github/workflows/unpublish-broken-versions.yml
+++ b/.github/workflows/unpublish-broken-versions.yml
@@ -1,0 +1,45 @@
+name: Unpublish Broken Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "yes" to confirm unpublishing broken versions'
+        required: true
+        default: 'no'
+
+jobs:
+  unpublish-broken-versions:
+    if: github.event.inputs.confirm == 'yes'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Unpublish broken version 2.1.0
+        run: npm unpublish @vabole/patcher@2.1.0
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Unpublish broken version 2.1.1
+        run: npm unpublish @vabole/patcher@2.1.1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Unpublish broken version 2.1.2
+        run: npm unpublish @vabole/patcher@2.1.2
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          
+      - name: Verify unpublished versions
+        run: |
+          echo "Checking published versions..."
+          npm view @vabole/patcher versions
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ Thank you for considering contributing to Patcher!
 
 1. Clone the repository
 2. Install dependencies: `npm install`
-3. Run tests: `npm test`
+3. Set up Git hooks (prevents accidental commits to main branch): `npm run dev:setup`
+4. Run tests: `npm test`
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vabole/patcher",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:bin-scoped-package": "node test/bin-scoped-package-test.js",
     "test:fix-verification": "node test/fix-verification-test.js",
     "test:cli-streamlined": "node test/run-cli-streamlined-test.js",
-    "postinstall": "node scripts/setup-git-hooks.js",
+    "dev:setup": "node scripts/setup-git-hooks.js",
     "setup-git-hooks": "node scripts/setup-git-hooks.js",
     "publish:version": "node scripts/publish.js",
     "publish:patch": "node scripts/publish.js --type patch --yes",

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 program
   .name('patcher')
   .description('Patch installed npm packages')
-  .version('2.1.2')
+  .version('2.1.3')
   .argument('<package-name>', 'Package name to patch')
   .option('-f, --file <config-file>', 'Use a specific configuration file instead of looking in ~/.patcher')
   .option('-u, --undo', 'Undo previous patches')


### PR DESCRIPTION
## Summary
- Removes postinstall script that causes errors during global installation
- Adds dev:setup script for developers to set up Git hooks manually
- Updates CONTRIBUTING.md with instructions for developers

## Impact
This fix allows users to install the package globally without errors while maintaining Git hook protection for developers.

## Additional Steps Required After Merge
1. Run the 'Unpublish Broken Versions' workflow:
   - Go to Actions > Unpublish Broken Versions
   - Click 'Run workflow'
   - Select branch: main
   - Enter 'yes' to confirm
   - Click 'Run workflow'

2. After the workflow completes successfully, remove the workflow file:
   - Delete .github/workflows/unpublish-broken-versions.yml
   - Commit with message: 'Remove one-time unpublish workflow'

These steps will clean up broken versions (2.1.0-2.1.2) from the npm registry.